### PR TITLE
Some tweaks to get more data out of an epub

### DIFF
--- a/epub_meta/collector.py
+++ b/epub_meta/collector.py
@@ -173,7 +173,7 @@ def _discover_identifiers(opf_xmldoc):
 
 
 def _discover_subject(opf_xmldoc):
-    return __discover_dc(opf_xmldoc, 'subject')
+    return __discover_dc(opf_xmldoc, 'subject', first_only=False)
 
 
 def _discover_cover_image(zf, opf_xmldoc, opf_filepath):

--- a/epub_meta/collector.py
+++ b/epub_meta/collector.py
@@ -91,6 +91,10 @@ def _discover_language(opf_xmldoc):
     return __discover_dc(opf_xmldoc, 'language')
 
 
+def _discover_description(opf_xmldoc):
+    return __discover_dc(opf_xmldoc, 'description')
+
+
 def _find_author_from_dom(xmldoc):
     # Only find a single author now with this algorithm but returning a list
     # because that's what caller expects
@@ -364,6 +368,7 @@ def get_epub_metadata(filepath, read_cover_image=True, read_toc=True):
         'epub_version': _discover_epub_version(opf_xmldoc),
         'title': _discover_title(opf_xmldoc),
         'language': _discover_language(opf_xmldoc),
+        'description': _discover_description(opf_xmldoc),
         'authors': _discover_authors(opf_xmldoc, authors_html=authors_html),
         'publisher': _discover_publisher(opf_xmldoc),
         'publication_date': _discover_publication_date(opf_xmldoc,

--- a/epub_meta/tests/tests.py
+++ b/epub_meta/tests/tests.py
@@ -133,19 +133,19 @@ class GetEPubMetadataTests(unittest.TestCase):
 
     def test_subject(self):
         data = get_epub_metadata(os.path.join(dir_path, 'backbone-fundamentals.epub'))
-        self.assertEqual(data.subject, None)
+        self.assertEqual(data.subject, [])
         data = get_epub_metadata(os.path.join(dir_path, 'georgia-cfi-20120521.epub'))
-        self.assertEqual(data.subject, None)
+        self.assertEqual(data.subject, [])
         data = get_epub_metadata(os.path.join(dir_path, 'georgia-pls-ssml-20120322.epub'))
-        self.assertEqual(data.subject, None)
+        self.assertEqual(data.subject, [])
         data = get_epub_metadata(os.path.join(dir_path, 'mathjax_tests.epub'))
-        self.assertEqual(data.subject, None)
+        self.assertEqual(data.subject, [])
         data = get_epub_metadata(os.path.join(dir_path, 'moby-dick.epub'))
-        self.assertEqual(data.subject, None)
+        self.assertEqual(data.subject, [])
         data = get_epub_metadata(os.path.join(dir_path, 'progit.epub'))
-        self.assertEqual(data.subject, 'Software Development')
+        self.assertEqual(data.subject, ['Software Development'])
         data = get_epub_metadata(os.path.join(dir_path, 'high-performance-computing-5.2.epub'))
-        self.assertEqual(data.subject, None)
+        self.assertEqual(data.subject, [])
 
     def test_cover_image(self):
         data = get_epub_metadata(os.path.join(dir_path, 'backbone-fundamentals.epub'))


### PR DESCRIPTION
It's nice to get more info such as book description (if present) and all the subjects (not just the first one).