### PR TITLE
Bug fix: Pathing errors.

### DIFF
--- a/epub_meta/collector.py
+++ b/epub_meta/collector.py
@@ -1,6 +1,5 @@
 import base64
 import os
-import os.path
 from xml.dom import minidom
 import zipfile
 import sys
@@ -210,7 +209,7 @@ def _discover_cover_image(zf, opf_xmldoc, opf_filepath):
         # The cover image path is relative to the OPF file
         base_dir = os.path.dirname(opf_filepath)
         # Also, normalize the path (ie opfpath/../cover.jpg -> cover.jpg)
-        coverpath = os.path.normpath(os.path.join(base_dir, filepath))
+        coverpath = f'{base_dir}/{filepath}' if base_dir else filepath
         try:
             content = zf.read(coverpath)
         except KeyError:
@@ -234,8 +233,8 @@ def _discover_toc(zf, opf_xmldoc, opf_filepath):
         # The xhtml file path is relative to the OPF file
         base_dir = os.path.dirname(opf_filepath)
         # print('- Reading Nav file: {}/{}'.format(base_dir, filepath))
-        npath = os.path.normpath(os.path.join(base_dir, filepath))
-        nav_content = zf.read(npath)
+        xhtml = f'{base_dir}/{filepath}' if base_dir else filepath
+        nav_content = zf.read(xhtml)
         toc_xmldoc = minidom.parseString(nav_content)
 
         _toc = []
@@ -277,8 +276,8 @@ def _discover_toc(zf, opf_xmldoc, opf_filepath):
             # The ncx file path is relative to the OPF file
             base_dir = os.path.dirname(opf_filepath)
             # print('- Reading NCX file: {}/{}'.format(base_dir, filepath))
-            npath = os.path.normpath(os.path.join(base_dir, filepath))
-            ncx_content = zf.read(npath)
+            ncx = f'{base_dir}/{filepath}' if base_dir else filepath
+            ncx_content = zf.read(ncx)
 
             toc_xmldoc = minidom.parseString(ncx_content)
 
@@ -355,7 +354,7 @@ def get_epub_metadata(filepath, read_cover_image=True, read_toc=True):
         # e.g.: <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
         opf_filepath = container_xmldoc.getElementsByTagName('rootfile')[0].attributes['full-path'].value
 
-        opf = zf.read(os.path.normpath(opf_filepath))
+        opf = zf.read(opf_filepath)
         opf_xmldoc = minidom.parseString(opf)
     except IndexError:
         raise EPubException("Cannot parse raw metadata from {}".format(


### PR DESCRIPTION
I was getting a lot of errors with reading the EPUB's contents:

```
Error with loading 'algorithmicthinking_aproblem-basedintroduction.epub': "There is no item named 'OEBPS\\\\9781718500815.opf' in the archive"
Error with loading 'algorithmsinanutshell.epub': "There is no item named 'OEBPS\\\\content.opf' in the archive"
Error with loading 'apprenticeshippatterns.epub': "There is no item named 'OEBPS\\\\content.opf' in the archive"
Error with loading 'artofagiledevelopment2e_V2.epub': "There is no item named 'OEBPS\\\\content.opf' in the archive"
Error with loading 'artofreadablecode.epub': "There is no item named 'OEBPS\\\\content.opf' in the archive"
Finished naming files in 'D:\KikoBrothers\Jerry\Documents\Dev\BitBucket\utils\books\ChildDir'
Error with loading 'clojureforthebraveandtrue.epub': "There is no item named 'OEBPS\\\\html\\\\9781593275914.opf' in the archive"
Error with loading 'cloudnativego.epub': "There is no item named 'OEBPS\\\\content.opf' in the archive"
['Elijah Meeks'] - D3.js in Action, Second Edition: Data visualization with JavaScript
['Ashley Davis'] - Data Wrangling with JavaScript
```

There were a lot of extra `\`'s when trying to access the EPUB metadata files. After a lot of research and discussion on the Python Discord, turns out that you don't need to use `os.path` to build your path strings when traversing a zipfile. This was news to me, [here](https://stackoverflow.com/a/60276958/4052494) is a Stackoverflow answer providing more details about it.

I have removed all the code where `os.path` is used to build a string to traverse the zipfile and have tested it with the sample EPUBs in this repo including 10 additional EPUBs on my machine with no issues. Though, I'm not sure why this **did** work with some EPUBs before this fix.
